### PR TITLE
Updated request_api to retry max_attempts at check_progress_interval_secs interval

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,26 +2,26 @@ language: python
 sudo: false
 
 matrix:
-    include:
-    - python: 3.6
-      dist: xenial
-      env: TOXENV=py36
+  include:
     - python: 3.7
-      dist: xenial
+      dist: bionic
       env: TOXENV=py37
-    - python: nightly
-      dist: xenial
+    - python: 3.8
+      dist: bionic
       env: TOXENV=py38
+    - python: nightly
+      dist: bionic
+      env: TOXENV=py39
     allow_failures:
-    - env: TOXENV=py38
+    - env: TOXENV=py39
 
 before_install:
-    - python -m pip install --upgrade setuptools pip virtualenv
+  - python -m pip install --upgrade setuptools pip virtualenv
 
 # command to install dependencies
 install:
-    - pip install -r requirements-build.txt
+  - pip install -r requirements-build.txt
 
 # command to run tests
 script:
-    - tox
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,17 @@ sudo: false
 
 matrix:
   include:
-    - python: 3.7
-      dist: bionic
-      env: TOXENV=py37
-    - python: 3.8
-      dist: bionic
-      env: TOXENV=py38
-    - python: nightly
-      dist: bionic
-      env: TOXENV=py39
-    allow_failures:
-    - env: TOXENV=py39
+  - python: 3.7
+    dist: bionic
+    env: TOXENV=py37
+  - python: 3.8
+    dist: bionic
+    env: TOXENV=py38
+  - python: nightly
+    dist: bionic
+    env: TOXENV=py39
+  allow_failures:
+  - env: TOXENV=py39
 
 before_install:
   - python -m pip install --upgrade setuptools pip virtualenv

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,14 +1,20 @@
-1.0.0 - 12/03/2019
+1.0.1 - 2020-02-12
+==================
+- When the API server is overloaded with requests it returns response.status_code 529. In this case request_api()
+  should not return the response before the the API accepts the request and status_code 200 is returned.
+  Updated `request_api` to retry `max_attempts` at `check_progress_interval_secs` interval.
+- Support building with Python 3.8 and Python 3.9.
+
+1.0.0 - 2019-03-12
 ==================
 - Support only Python >= 3.6.
 - Add report column "TLS 1.3".
 
-
-0.2.0 - 12/02/2018
+0.2.0 - 2018-02-12
 ==================
 - Add a column for certificate expiry date to the reports.
 
 
-0.1.0 - 02/02/2017
+0.1.0 - 2017-02-02
 ==================
 - Initial version of SSL Labs scanning and reporting

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -3,7 +3,7 @@
 - When the API server is overloaded with requests it returns response.status_code 529. In this case request_api()
   should not return the response before the the API accepts the request and status_code 200 is returned.
   Updated `request_api` to retry `max_attempts` at `check_progress_interval_secs` interval.
-- Support building with Python 3.8 and Python 3.9.
+- Support building/testing with Python 3.8.
 
 1.0.0 - 2019-03-12
 ==================

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,7 @@
 from setuptools import setup, find_packages
 
-
 __title__ = "ssllabsscan"
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 __author__ = "Kay Hau"
 __email__ = "virtualda@gmail.com"
 __uri__ = "https://github.com/kyhau/ssllabs-scan"
@@ -22,6 +21,8 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3 :: Only",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
-envlist = py36,py37,py38
+envlist = py37,py38,p739
 skip_missing_interpreters = True
 
 [testenv]
 basepython =
-    py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9
 install_command =
     python -m pip install {opts} {packages} -cconstraints.txt
 deps =
@@ -19,7 +19,7 @@ commands =
     pip check
     python -m pytest --junit-xml "junit-{envname}.xml"
 
-[testenv:py36]
+[testenv:py38]
 commands =
     pip check
     python -m pytest --cov . --cov-config=tox.ini --cov-report xml:coverage-{envname}.xml --junit-xml "junit-{envname}.xml" ssllabsscan


### PR DESCRIPTION
- When the API server is overloaded with requests it returns response.status_code 529. In this case request_api() should not return the response before the the API accepts the request and status_code 200 is returned.
Updated `request_api` to retry `max_attempts` at `check_progress_interval_secs` interval.
- Support building/testing with Python 3.8.