### PR TITLE
Fixing README and IPv6 scaning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ ENV/
 # Rope project settings
 .ropeproject
 .idea/
+
+# Visual Studio Code Workspace settings
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "spellright.language": [
+        "en"
+    ],
+    "spellright.documentTypes": [
+        "latex",
+        "plaintext"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-    "spellright.language": [
-        "en"
-    ],
-    "spellright.documentTypes": [
-        "latex",
-        "plaintext"
-    ]
-}

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@
 
 Support Python >= 3.6
 
-This tool calls the SSL Labs [API v2](https://github.com/ssllabs/ssllabs-scan/blob/master/ssllabs-api-docs.md) to do SSL testings on servers.
+This tool calls the SSL Labs [API v3](https://github.com/ssllabs/ssllabs-scan/blob/master/ssllabs-api-docs-v3.md) to do SSL testings on servers.
 
-- **TODO**: use v3 instead of v2
-- **NOTE**: Please note that the SSL Labs Assessment API has access rate limits. You can find more details in the sections "Error Response Status Codes" and "Access Rate and Rate Limiting" in the official [SSL Labs API Documentation](https://github.com/ssllabs/ssllabs-scan/blob/master/ssllabs-api-docs.md). Some common status codes are:
+- **NOTE**: Please note that the SSL Labs Assessment API has access rate limits. You can find more details in the sections "Error Response Status Codes" and "Access Rate and Rate Limiting" in the official [SSL Labs API Documentation](https://github.com/ssllabs/ssllabs-scan/blob/master/ssllabs-api-docs-v3.md). Some common status codes are:
     - 400 - invocation error (e.g., invalid parameters)
     - 429 - client request rate too high or too many new assessments too fast
     - 500 - internal error

--- a/ssllabsscan/ssllabs_client.py
+++ b/ssllabsscan/ssllabs_client.py
@@ -59,7 +59,7 @@ class SSLLabsClient():
         # write the summary to file
         self.append_summary_csv(summary_csv_file, host, data)
 
-    def start_new_scan(self, host, publish="off", startNew="off", all="done", ignoreMismatch="on"):
+    def start_new_scan(self, host, publish="off", startNew="on", all="done", ignoreMismatch="on"):
         path = API_URL
         payload = {
             "host": host,
@@ -98,8 +98,8 @@ class SSLLabsClient():
         with open(summary_file, "a") as outfile:
             na = self.prepare_datetime(data["certs"][0]["notAfter"])
             for ep in data["endpoints"]:
-                # Endpoints with IPv6 addresses will not return a full complement of details
-                if ":" in ep["ipAddress"]:
+                # Skip endpoints that were not contactable during the scan (e.g. GitHub Pages URLs with IPv6 endpoints)
+                if "Unable" in ep["statusMessage"]:
                     continue
                 # see SUMMARY_COL_NAMES
                 summary = [

--- a/ssllabsscan/ssllabs_client.py
+++ b/ssllabsscan/ssllabs_client.py
@@ -59,7 +59,7 @@ class SSLLabsClient():
         # write the summary to file
         self.append_summary_csv(summary_csv_file, host, data)
 
-    def start_new_scan(self, host, publish="off", startNew="on", all="done", ignoreMismatch="on"):
+    def start_new_scan(self, host, publish="off", startNew="off", all="done", ignoreMismatch="on"):
         path = API_URL
         payload = {
             "host": host,


### PR DESCRIPTION
- Fixed README.md to reflect that API v3 is now being used.
- Changed the check from IPv6 address to "statusMessage" when deciding to skip uncontactable endpoints. (ssllabs_client)
- Reverted "startNew" argument to "on". (ssllabs_client)