### PR TITLE
Subset drownVulnerable, support Python 3.12

### DIFF
--- a/.github/workflows/ci-workflow.yaml
+++ b/.github/workflows/ci-workflow.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.9, "3.10", 3.11, 3.12]
     steps:
     - name: Checkout sources
       uses: actions/checkout@v4
@@ -26,18 +26,18 @@ jobs:
     - name: Set tox setting
       id: ToxSetting
       run: |
-        if [[ "${{ matrix.python-version }}" == "3.8" ]]
+        if [[ "${{ matrix.python-version }}" == "3.12" ]]
         then
-          echo "toxenv=py38" >> $GITHUB_OUTPUT
-        elif [[ "${{ matrix.python-version }}" == "3.9" ]]
-        then
-          echo "toxenv=py39" >> $GITHUB_OUTPUT
-        elif [[ "${{ matrix.python-version }}" == "3.10" ]]
-        then
-          echo "toxenv=py310" >> $GITHUB_OUTPUT
+          echo "toxenv=py312" >> $GITHUB_OUTPUT
         elif [[ "${{ matrix.python-version }}" == "3.11" ]]
         then
           echo "toxenv=py311" >> $GITHUB_OUTPUT
+        elif [[ "${{ matrix.python-version }}" == "3.10" ]]
+        then
+          echo "toxenv=py310" >> $GITHUB_OUTPUT
+        elif [[ "${{ matrix.python-version }}" == "3.9" ]]
+        then
+          echo "toxenv=py39" >> $GITHUB_OUTPUT
         else
           exit 1
         fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+
+2.3.0 - 2024-04-01
+==================
+
+### Added
+- Support Python 3.12
+
+### Changed
+- Update code to handle [SSL Labs – Sunsetting DROWN Test](https://notifications.qualys.com/product/2024/03/28/ssl-labs-sunsetting-drown-test) (#195). Now `Vuln Drown` returns `None` in csv and html reports.
+
+## Removed
+- No longer support Python 3.8
+
+
 2.2.0 - 2023-12-13
 ==================
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in [CHANGELOG](./CHANGELO
 
 ---
 ## Built with
-- Python - support Python 3.8, 3.9, 3.10, 3.11.
+- Python - support Python 3.9, 3.10, 3.11, 3.12.
 - [CodeQL](https://codeql.github.com) is [enabled](.github/workflows/codeql-analysis.yml) in this repository.
 - [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates) is [enabled](.github/dependabot.yml) for auto dependency updates.
 - [Gitleaks](https://github.com/gitleaks/gitleaks) and [TruffleHog](https://github.com/trufflesecurity/trufflehog) are enabled in this GitHub Actions [workflow](.github/workflows/secrets-scan.yml) for detecting and preventing hardcoded secrets.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,5 +8,6 @@ pytest~=8.1
 pytest-cov~=5.0
 pytest-gitignore~=1.3
 pytest-mock~=3.14
+setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 wheel~=0.43
 -e.

--- a/sample/summary.csv
+++ b/sample/summary.csv
@@ -1,4 +1,4 @@
 #Host,Grade,HasWarnings,Cert Expiry,Chain Status,Forward Secrecy,Heartbeat ext,Vuln Beast,Vuln Drown,Vuln Heartbleed,Vuln FREAK,Vuln openSsl Ccs,Vuln openSSL LuckyMinus20,Vuln POODLE,Vuln POODLE TLS,Support RC4,RC4 with modern protocols,RC4 Only,TLS 1.3,TLS 1.2,TLS 1.1,TLS 1.0,SSL 3.0 INSECURE,SSL 2.0 INSECURE
-duckduckgo.com,A+,False,2022-11-26,none,Yes (with most browsers) ROBUST,False,False,False,False,False,False,False,False,False,False,False,False,Yes,Yes,No,No,No,No
-google.com,B,False,2022-11-07,none,With modern browsers,False,True,False,False,False,False,False,False,False,False,False,False,Yes,Yes,Yes,Yes,No,No
-google.com,B,False,2022-11-07,none,With modern browsers,False,True,False,False,False,False,False,False,False,False,False,False,Yes,Yes,Yes,Yes,No,No
+duckduckgo.com,A+,False,2024-11-05,none,Yes (with most browsers) ROBUST,False,False,None,False,False,False,False,False,False,False,False,False,Yes,Yes,No,No,No,No
+google.com,B,False,2024-05-27,none,With modern browsers,False,True,None,False,False,False,False,False,False,False,False,False,Yes,Yes,Yes,Yes,No,No
+google.com,B,False,2024-05-27,none,With modern browsers,False,True,None,False,False,False,False,False,False,False,False,False,Yes,Yes,Yes,Yes,No,No

--- a/sample/summary.html
+++ b/sample/summary.html
@@ -39,12 +39,12 @@
 	<td>duckduckgo.com</td>
 	<td>A+</td>
 	<td>False</td>
-	<td>2022-11-26</td>
+	<td>2024-11-05</td>
 	<td>none</td>
 	<td>Yes (with most browsers) ROBUST</td>
 	<td>False</td>
 	<td>False</td>
-	<td>False</td>
+	<td>None</td>
 	<td>False</td>
 	<td>False</td>
 	<td>False</td>
@@ -65,12 +65,12 @@
 	<td>google.com</td>
 	<td>B</td>
 	<td>False</td>
-	<td>2022-11-07</td>
+	<td>2024-05-27</td>
 	<td>none</td>
 	<td>With modern browsers</td>
 	<td>False</td>
 	<td>True</td>
-	<td>False</td>
+	<td>None</td>
 	<td>False</td>
 	<td>False</td>
 	<td>False</td>
@@ -91,12 +91,12 @@
 	<td>google.com</td>
 	<td>B</td>
 	<td>False</td>
-	<td>2022-11-07</td>
+	<td>2024-05-27</td>
 	<td>none</td>
 	<td>With modern browsers</td>
 	<td>False</td>
 	<td>True</td>
-	<td>False</td>
+	<td>None</td>
 	<td>False</td>
 	<td>False</td>
 	<td>False</td>

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 __title__ = "ssllabsscan"
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 __author__ = "Kay Hau"
 __email__ = "virtualda@gmail.com"
 __uri__ = "https://github.com/kyhau/ssllabs-scan"
@@ -19,10 +19,10 @@ __entry_points__ = {
 
 CLASSIFIERS = [
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
 ]
 
@@ -38,7 +38,7 @@ setup(
     install_requires=__requirements__,
     name=__title__,
     packages=find_packages(exclude=["tests"]),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     url=__uri__,
     version=__version__,
     zip_safe=False,

--- a/ssllabsscan/ssllabs_client.py
+++ b/ssllabsscan/ssllabs_client.py
@@ -139,7 +139,7 @@ class SSLLabsClient():
                     FORWARD_SECRECY[str(ep["details"]["forwardSecrecy"])],
                     ep["details"]["heartbeat"],
                     ep["details"]["vulnBeast"],
-                    ep["details"]["drownVulnerable"],
+                    ep["details"].get("drownVulnerable"),
                     ep["details"]["heartbleed"],
                     ep["details"]["freak"],
                     False if ep["details"]["openSslCcs"] == 1 else True,

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
-envlist = py38,py39,py310,py311
+envlist = py39,py310,py311,py312
 skip_missing_interpreters = True
 
 [testenv]
 basepython =
-    py38: python3.8
     py39: python3.9
     py310: python3.10
     py311: python3.11
+    py312: python3.12
 install_command =
     python -m pip install {opts} {packages} -cconstraints.txt
 deps =
@@ -23,7 +23,7 @@ commands =
     pip check
     python -m pytest --junit-xml "junit-{envname}.xml"
 
-[testenv:py311]
+[testenv:py312]
 commands =
     pip check
     python -m pytest --cov . --cov-config=tox.ini --cov-report xml:coverage-{envname}.xml --junit-xml "junit-{envname}.xml" ssllabsscan


### PR DESCRIPTION
## Proposed changes
- Update code to handle [SSL Labs – Sunsetting DROWN Test](https://notifications.qualys.com/product/2024/03/28/ssl-labs-sunsetting-drown-test) (#195). Now `Vuln Drown` returns `None` in csv and html reports.
- Support Python 3.12
- No longer support Python 3.8
- Ticket: https://github.com/kyhau/ssllabs-scan/issues/195

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update (if none of the other choices apply)

## Checklist
- [x] Add or update tests that prove the fix is effective or that the feature works
- [x] Add or update workflows for deployment
- [x] Add or update README, CHANGELOG
